### PR TITLE
Fix JSON syntax error, add logging for try/except failure in decompose

### DIFF
--- a/pages/01_optStoic_test.py
+++ b/pages/01_optStoic_test.py
@@ -490,7 +490,7 @@ def optimal_stoic(reactant,product,add_info,min_int_val,max_int_val):
                         metab_detail_dict[id] = extract_det(smiles)
                 novel_mets[id] = smiles
                 try:
-                    novel_mets = parse_novel_molecule(json.loads({id:smiles}))
+                    novel_mets = parse_novel_molecule({id:smiles})
                     #st.write(novel_mets)
                     novel_smiles = parse_novel_smiles(novel_mets)
                     novel_decomposed_r1 = decompse_novel_mets_rad1(novel_smiles)
@@ -501,7 +501,9 @@ def optimal_stoic(reactant,product,add_info,min_int_val,max_int_val):
                     novel_smiles = None
                     novel_decomposed_r1 = None
                     novel_decomposed_r2 = None
-                    
+                    print(f'ERROR: Failed to decompose - {str(e)}')
+                    return
+                
                 dG_values_metanetx[id], st_id = get_dG0(id, pH, I, smiles, loaded_model, molsig_r1, molsig_r2, novel_decomposed_r1, novel_decomposed_r2, novel_mets, met_2_kegg)
                 #id, pH, I, smiles, loaded_model, molsig_r1, molsig_r2, novel_decomposed_r1, novel_decomposed_r2, novel_mets, met_2_kegg
 


### PR DESCRIPTION
## Problem
`json.loads()` expects a string, but we are passing it a dictionary

No logging is present for the case where this try/except encounters a failure

## Approach
* fix: remove the call to `json.loads`, and just pass in the dictionary 
* fix: add simple logging for the case when an exception is hit in this try/except
* fix: `return` if an exception is encountered here, since subsequent calculations will likely not work if this failed 

## How to Test
1. Run OptStoic for the following edge case inputs:
    * reactant / primary_precursor = `MNXM161204`
    * product / target_molecule = `MNXM872`
2. Wait for completion
    * You should see no failure in the Decompose step (where we see the try/except in the code)
    * You might see that the process goes OOM in the later stages - this is ok as long as we get through the Decompose stage :+1:
3. Try simpler / more common examples (not edge case) to ensure that this fix does not break other cases